### PR TITLE
Update for configurable jupiter_swap_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Open the installation folder and create a file titled `config.json` with the fol
   "other_mint": "",
   "other_mint_decimals": "",
   "other_mint_symbol": "",
-  "trading_interval_seconds": ""
+  "trading_interval_seconds": "",
+  "jupiter_swap_api": "https://public.jupiterapi.com"
 }
 ```
+
 Next, install the dependencies for Soltrade by opening Python and running the following command.
 This will install automatically install the required modules and their respective versions.
 ```
@@ -40,6 +42,11 @@ Alternatively, you can install using poetry:
 python -m pip install poetry
 poetry install
 ```
+
+### Self-Hosted Jupiter API Support
+
+You can set custom URLs on `jupiter_swap_api` in `config.json` for any self-hosted Jupiter APIs. Like the [V6 Swap API](https://station.jup.ag/docs/apis/self-hosted), [Public Jupiter API](https://www.jupiterapi.com/) or [QuickNode's Metis API](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api). We default to the [Public Jupiter API](https://www.jupiterapi.com/) since its faster and has higher rate limits that the Jupiter hosted endpoint.
+
 
 ### Usage
 Make sure you have deposited at least 1 $USDC in your connected wallet for Soltrade to begin trading, along with 0.1 $SOL to pay for gas.

--- a/example.config.json
+++ b/example.config.json
@@ -5,5 +5,6 @@
   "other_mint": "StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT",
   "other_mint_decimals": "9",
   "other_mint_symbol": "STEP",
-  "trading_interval_seconds": "30"
+  "trading_interval_seconds": "30",
+  "jupiter_swap_api": "https://public.jupiterapi.com"
 }

--- a/soltrade/config.py
+++ b/soltrade/config.py
@@ -21,6 +21,7 @@ class Config:
         self.trading_interval_seconds = None
         self.slippage = None  # bps
         self.computeUnitPriceMicroLamports = None
+        self.jupiter_swap_api = None
         self.load_config()
 
     def load_config(self):
@@ -41,6 +42,7 @@ class Config:
                 self.trading_interval_seconds = int(config_data.get("trading_interval_seconds", "60"))
                 self.slippage = int(config_data.get("slippage", "50"))
                 self.computeUnitPriceMicroLamports = int(config_data.get("computeUnitPriceMicroLamports", 20 * 14000))  # default fee of roughly $.04 today
+                self.jupiter_swap_api  = config_data.get("jupiter_swap_api", "https://public.jupiterapi.com")
             except json.JSONDecodeError as e:
                 log_general.error(f"Error parsing JSON: {e}")
                 exit(1)

--- a/soltrade/transactions.py
+++ b/soltrade/transactions.py
@@ -41,7 +41,7 @@ async def create_exchange(input_amount, input_token_mint):
         token_decimals = config().other_mint_decimals
     
     # Finds the response and converts it into a readable array
-    api_link = f"https://quote-api.jup.ag/v6/quote?inputMint={input_token_mint}&outputMint={output_token_mint}&amount={int(input_amount * token_decimals)}&slippageBps={config().slippage}"
+    api_link = f"{config().jupiter_swap_api}/quote?inputMint={input_token_mint}&outputMint={output_token_mint}&amount={int(input_amount * token_decimals)}&slippageBps={config().slippage}"
     log_transaction.info(f"Soltrade API Link: {api_link}")
     async with httpx.AsyncClient() as client:
         response = await client.get(api_link)
@@ -62,7 +62,7 @@ async def create_transaction(quote):
 
     # Returns the JSON parsed response of Jupiter
     async with httpx.AsyncClient() as client:
-        response = await client.post("https://quote-api.jup.ag/v6/swap", json=parameters)
+        response = await client.post(f"{config().jupiter_swap_api}/swap", json=parameters)
         return response.json()
 
 


### PR DESCRIPTION
This PR updates soltrade to have the Jupiter Swap API as a configuration with a fallback in case one isn't provided. This allows you to easily swap to a self hosted Jupiter API instance if you choose.