### PR TITLE
Update requirements.txt for bakcktesting and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,6 @@ dmypy.json
 
 # Visual Studio Code
 .vscode
-
+.idea/
 
 config.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ httpx==0.23.3
 pandas==1.5.3
 requests==2.28.2
 solana==0.29.0
+matplotlib==3.2.2


### PR DESCRIPTION
By default there is dependency missing in requirements for backtesting.