### PR TITLE
Update backtrader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 apscheduler==3.10.1
-backtrader==1.9.76.123
+backtrader==1.9.78.123
 base58==2.1.1
 httpx==0.23.3
 pandas==1.5.3

--- a/testing/backtest.py
+++ b/testing/backtest.py
@@ -16,13 +16,14 @@ class SoltradeStrategy(bt.Strategy):
     def next(self):
 
         if not self.position:
-            if self.data.close <= self.stoploss or self.data.close >= self.takeprofit:
-                self.close()
             if (self.ema_short > self.ema_medium or self.data.close < self.bb.lines.bot) and self.rsi <= 31:
                 self.buy()
                 self.stoploss = self.data.close * 0.925
                 self.takeprofit = self.data.close * 1.25
         else:
+            if self.data.close <= self.stoploss or self.data.close >= self.takeprofit:
+                self.close()
+                
             if (self.ema_short < self.ema_medium or self.data.close > self.bb.lines.top) and self.rsi >= 68:
                 self.close()
 


### PR DESCRIPTION
Have tried to run the back the backtest.py but it was complaining about matplotlib 

```
❯❯ python testing/backtest.py 
Traceback (most recent call last):
  File "/home/soltrade/testing/backtest.py", line 54, in <module>
    cerebro.plot()
  File "/home/soltrade/.venv/lib/python3.12/site-packages/backtrader/cerebro.py", line 974, in plot
    from . import plot
  File "/home/soltrade/.venv/lib/python3.12/site-packages/backtrader/plot/__init__.py", line 42, in <module>
    from .plot import Plot, Plot_OldSync
  File "/home/soltrade/.venv/lib/python3.12/site-packages/backtrader/plot/plot.py", line 44, in <module>
    from . import locator as loc
  File "/home/soltrade/.venv/lib/python3.12/site-packages/backtrader/plot/locator.py", line 35, in <module>
    from matplotlib.dates import (HOURS_PER_DAY, MIN_PER_HOUR, SEC_PER_MIN,
ImportError: cannot import name 'warnings' from 'matplotlib.dates' (/home/soltrade/.venv/lib/python3.12/site-packages/matplotlib/dates.py)

```
updating to the latest version of backtrader works
I am running Python 3.12.3

Also Backtest.py needed update as the check for stoploss takeprofit were only check when there was no open position