### PR TITLE
Discard outdated position.json data

### DIFF
--- a/soltrade/trading.py
+++ b/soltrade/trading.py
@@ -79,6 +79,13 @@ take_profit:            {takeprofit}
             return
     else:
         input_amount = find_balance(config().secondary_mint)
+        
+        # sometimes position.json might contain wrong or outdated data
+        if input_amount == 0.0:
+            stoploss = takeprofit = market().sl = market().tp = 0
+            market().update_position(False, stoploss, takeprofit)
+            log_transaction.info("Soltrade has detected outdated data in position.json. Reseting position.")
+            return
 
         if price <= stoploss or price >= takeprofit:
             log_transaction.info("Soltrade has detected a sell signal. Stoploss or takeprofit has been reached.")


### PR DESCRIPTION
I have encounced a situation where position.json contained 
```
{"is_open": true, "sl": 0.6535125, "tp": 0.883125}
```
meanwhile there was no real position, had probably been already executed but the position.json was not properly updated.  Perhaps this resulted from a forced stop (there is no graceful stop of the program is there ?)

This situation is bad as it creates an infinite loop.  The program trying to find a way to sell a position of 0 amount and hence it  results in an infinite loop 
```
2025-02-23 07:31:36     Soltrade is creating exchange for 0.0 JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN
2025-02-23 07:31:36     Soltrade API Link: https://quote-api.jup.ag/v6/quote?inputMint=JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN&outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&amount=0&slippageBps=50
2025-02-23 07:31:36     Soltrade is creating transaction for the following quote: 
{'error': 'Could not find any route', 'errorCode': 'COULD_NOT_FIND_ANY_ROUTE'}
```

Well this MR helps realize this an reset the position.json on first encounter